### PR TITLE
Update to the latest version of darkfi (0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Installation (impure)
 
-This flake sticks to the initial design and uses Makefiles maintainedby the
+This flake sticks to the initial design and uses Makefiles maintained by the
 DarkFi core team.
 
 Using nix builders would make the package evaluation pure, but would although
-lead to duplicate and unevitably to an out of date flake.
+lead to duplicate and inevitably to an out of date flake.
 
 Make this flake pure
 
@@ -33,7 +33,7 @@ Either in your nixos configuration:
 nix.settings.sandbox = "relaxed"
 ```
 
-or exceptionnaly via command-line as an argument of an installation command.
+or exceptionally via command-line as an argument of an installation command.
 
 ```sh
 nix-env -i github:darkrenaissance/darki?dir=contrib/nix --no-sandbox

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ lead to duplicate and unevitably to an out of date flake.
 
 Make this flake pure
 
+
+### Building the flake
+To build the flake on the terminal with the project as the current working directory
+
+```sh
+nix build .#packages.x86_64-linux.default
+```
+
+💡 Need to have the sandbox thing from below set in the system configuration
+
 ### Prerequisites
 
 The flake buildPhases need network access that are by default disabled by nix.

--- a/default.nix
+++ b/default.nix
@@ -1,99 +1,99 @@
-{
-  pkgs ? import <nixpkgs> {},
-  lib,
-  ...
-}:
-with pkgs; let
+{ pkgs ? import <nixpkgs> { }, lib, ... }:
+with pkgs;
+let
   source = pkgs.fetchFromGitHub {
     owner = "darkrenaissance";
     repo = "darkfi";
     # rev = "v0.4.1";
     # hash = "sha256-NmrFtx5S7+JpPwkRPIQsR6rCJ7u8xrKWOHZk7J1wbfs=";
     rev = "master";
-    hash = "sha256-z1YdEG+E7i2N65u7NljrgQjpLMfDcvU9xGplCQK/vU0=";
+    hash = "sha256-pgCxgWmPOBv8ExeJVkyw8QRTrisKUK6Wk2QTDRtnIqY=";
   };
-in
-  stdenv.mkDerivation rec {
-    # Declare nix derivation as intentionnaly impure
-    # for compatibility with nixos configuration flag  `nix.settings.sandbox=relaxed`
-    __noChroot = true;
+in stdenv.mkDerivation rec {
+  # Declare nix derivation as intentionnaly impure
+  # for compatibility with nixos configuration flag  `nix.settings.sandbox=relaxed`
+  __noChroot = true;
 
-    name = "darkfi";
-    version = source.rev;
-    src = source;
+  name = "darkfi";
+  version = source.rev;
+  src = source;
 
-    # Skip cmake reconfigure
-    dontUseCmakeConfigure = true;
-    # Disable tests
-    checkType = "debug";
-    doCheck = false;
+  # Skip cmake reconfigure
+  dontUseCmakeConfigure = true;
+  # Disable tests
+  checkType = "debug";
+  doCheck = false;
 
-    buildPhase = ''
-      export HOME=$(mktemp -d)
-      export RUSTUP_USE_CURL=1
-      export CARGO_NET_GIT_FETCH_WITH_CLI=true
-      rustup toolchain install stable
-      # rustup toolchain install nightly
-      rustup target add wasm32-unknown-unknown --toolchain stable
-      # rustup target add wasm32-unknown-unknown --toolchain nightly
-      rustup default stable
-      # rustup default nightly
-      cargo check
-      make
-    '';
+  buildPhase = ''
+    export HOME=$(mktemp -d)
+    export RUSTUP_USE_CURL=1
+    export CARGO_NET_GIT_FETCH_WITH_CLI=true
+    export COMMITISH=${source.rev}
+    rustup toolchain install stable
+    # rustup toolchain install nightly
+    rustup target add wasm32-unknown-unknown --toolchain stable
+    # rustup target add wasm32-unknown-unknown --toolchain nightly
+    rustup default stable
+    # rustup default nightly
+    cargo check
+    make
+  '';
 
-    fixupPhase = ''
-    '';
+  fixupPhase = "";
 
-    nativeBuildInputs = with pkgs; [
-      # Nightly toolchains
-      llvmPackages.bintools
-      rustup
-      pkg-config
-      sqlcipher
-      gnumake
-      cmake
-      clang
-      libclang
-      llvm
-      git
-      openssl
-      cacert
-      wabt
-      jq
-      # v0.4.1
-      # libmpg123
+  nativeBuildInputs = with pkgs; [
+    # Nightly toolchains
+    llvmPackages.bintools
+    alsa-lib
+    rustup
+    sqlite
+    pkg-config
+    sqlcipher
+    gnumake
+    cmake
+    clang
+    libclang
+    llvm
+    git
+    openssl
+    cacert
+    wabt
+    jq
+    # v0.4.1
+    # libmpg123
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    find . -type f -executable ! -name "*.*" -exec cp {} $out/bin \;
+  '';
+
+  ## Manage toolchain with Rustup instead of nix-store
+  ## https://nixos.wiki/wiki/Rust
+  # RUSTC_VERSION = "stable";
+  RUSTC_VERSION = "nightly";
+  LIBCLANG_PATH =
+    pkgs.lib.makeLibraryPath [ pkgs.llvmPackages_latest.libclang.lib ];
+  shellHook = ''
+    export PATH=$PATH:''${CARGO_HOME:-~/.cargo}/bin
+    export PATH=$PATH:''${RUSTUP_HOME:-~/.rustup}/toolchains/$RUSTC_VERSION-x86_64-unknown-linux-gnu/bin/
+  '';
+  # Add precompiled library to rustc search path
+  RUSTFLAGS = builtins.map (a: "-L ${a}/lib") [
+    # add libraries here (e.g. pkgs.libvmi)
+  ];
+  # Add glibc, clang, glib and other headers to bindgen search path
+  BINDGEN_EXTRA_CLANG_ARGS =
+    # Includes with normal include path
+    (builtins.map (a: ''-I"${a}/include"'') [
+      # add dev libraries here (e.g. pkgs.libvmi.dev)
+      pkgs.glibc.dev
+    ])
+    # Includes with special directory paths
+    ++ [
+      ''
+        -I"${pkgs.llvmPackages_latest.libclang.lib}/lib/clang/${pkgs.llvmPackages_latest.libclang.version}/include"''
+      ''-I"${pkgs.glib.dev}/include/glib-2.0"''
+      "-I${pkgs.glib.out}/lib/glib-2.0/include/"
     ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      find . -type f -executable ! -name "*.*" -exec cp {} $out/bin \;
-    '';
-
-    ## Manage toolchain with Rustup instead of nix-store
-    ## https://nixos.wiki/wiki/Rust
-    # RUSTC_VERSION = "stable";
-    RUSTC_VERSION = "nightly";
-    LIBCLANG_PATH = pkgs.lib.makeLibraryPath [pkgs.llvmPackages_latest.libclang.lib];
-    shellHook = ''
-      export PATH=$PATH:''${CARGO_HOME:-~/.cargo}/bin
-      export PATH=$PATH:''${RUSTUP_HOME:-~/.rustup}/toolchains/$RUSTC_VERSION-x86_64-unknown-linux-gnu/bin/
-    '';
-    # Add precompiled library to rustc search path
-    RUSTFLAGS = builtins.map (a: ''-L ${a}/lib'') [
-      # add libraries here (e.g. pkgs.libvmi)
-    ];
-    # Add glibc, clang, glib and other headers to bindgen search path
-    BINDGEN_EXTRA_CLANG_ARGS =
-      # Includes with normal include path
-      (builtins.map (a: ''-I"${a}/include"'') [
-        # add dev libraries here (e.g. pkgs.libvmi.dev)
-        pkgs.glibc.dev
-      ])
-      # Includes with special directory paths
-      ++ [
-        ''-I"${pkgs.llvmPackages_latest.libclang.lib}/lib/clang/${pkgs.llvmPackages_latest.libclang.version}/include"''
-        ''-I"${pkgs.glib.dev}/include/glib-2.0"''
-        ''-I${pkgs.glib.out}/lib/glib-2.0/include/''
-      ];
-  }
+}


### PR DESCRIPTION
Went through the flake and made several adjustments:
- had to adjust the sha hash of the darkfi project for 0.5.0
- had to add sqlite as a dependency
- had to add alsa-lib as a dependency
- minor adjustments of the readme

Now the project builds again successfully with `nix build .#packages.x86_64-linux.default`.

I suggest to merge this PR to keep the flake up and running.